### PR TITLE
Add RoPE, Flash Attention, and safetensors export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install test data train-tiny train-small generate chat benchmark plot clean help
+.PHONY: all install test data train-tiny train-small generate chat benchmark plot export clean help
 
 help:
 	@echo "GhostLM — Cybersecurity Language Model"
@@ -41,6 +41,9 @@ chat:
 
 benchmark:
 	python scripts/benchmark.py --checkpoint checkpoints/best_model.pt
+
+export:
+	python scripts/export.py --checkpoint checkpoints/best_model.pt --format both
 
 plot:
 	python scripts/plot_training.py --output logs/training_curve.png

--- a/ghostlm/config.py
+++ b/ghostlm/config.py
@@ -20,6 +20,8 @@ class GhostLMConfig:
     d_ff: int = 2048
     dropout: float = 0.1
     bias: bool = True
+    use_rope: bool = False
+    use_flash_attention: bool = False
 
     # Training
     batch_size: int = 32

--- a/ghostlm/model.py
+++ b/ghostlm/model.py
@@ -9,13 +9,61 @@ import torch.nn.functional as F
 from ghostlm.config import GhostLMConfig
 
 
+class RotaryEmbedding(nn.Module):
+    """Rotary Position Embedding (RoPE).
+
+    Encodes relative position information directly into the attention
+    computation by rotating query and key vectors. Used by LLaMA, Mistral,
+    and most modern transformer architectures.
+    """
+
+    def __init__(self, head_dim: int, context_length: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2).float() / head_dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+        # Precompute cos/sin for all positions
+        t = torch.arange(context_length).float()
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("cos_cached", emb.cos(), persistent=False)
+        self.register_buffer("sin_cached", emb.sin(), persistent=False)
+
+    def forward(self, seq_len: int):
+        return self.cos_cached[:seq_len], self.sin_cached[:seq_len]
+
+
+def _rotate_half(x):
+    """Rotate the second half of the last dimension and negate it."""
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin):
+    """Apply rotary position embeddings to query and key tensors.
+
+    Args:
+        q: Query tensor of shape (B, n_heads, T, head_dim).
+        k: Key tensor of shape (B, n_heads, T, head_dim).
+        cos: Cosine frequencies of shape (T, head_dim).
+        sin: Sine frequencies of shape (T, head_dim).
+
+    Returns:
+        Tuple of (rotated_q, rotated_k).
+    """
+    cos = cos.unsqueeze(0).unsqueeze(0)  # (1, 1, T, head_dim)
+    sin = sin.unsqueeze(0).unsqueeze(0)
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
 class CausalSelfAttention(nn.Module):
     """Multi-head causal self-attention with autoregressive masking.
 
     Uses a single combined QKV projection for efficiency, then splits
-    the result into separate query, key, and value tensors. Scaled
-    dot-product attention is computed manually with explicit causal
-    masking via torch.tril.
+    the result into separate query, key, and value tensors. Supports
+    optional RoPE (Rotary Position Embeddings) and Flash Attention.
     """
 
     def __init__(self, config: GhostLMConfig):
@@ -23,7 +71,7 @@ class CausalSelfAttention(nn.Module):
 
         Args:
             config: GhostLMConfig containing d_model, n_heads, dropout,
-                    context_length, and bias settings.
+                    context_length, bias, use_rope, and use_flash_attention.
         """
         super().__init__()
         assert config.d_model % config.n_heads == 0, "d_model must be divisible by n_heads"
@@ -31,22 +79,30 @@ class CausalSelfAttention(nn.Module):
         self.n_heads = config.n_heads
         self.head_dim = config.d_model // config.n_heads
         self.context_length = config.context_length
+        self.use_rope = config.use_rope
+        self.use_flash_attention = config.use_flash_attention
+        self.dropout_p = config.dropout
 
         # Single combined QKV projection
         self.c_qkv = nn.Linear(config.d_model, 3 * config.d_model, bias=config.bias)
         self.proj = nn.Linear(config.d_model, config.d_model, bias=config.bias)
 
-        # Dropout applied to attention weights
+        # Dropout applied to attention weights (manual path only)
         self.attn_dropout = nn.Dropout(config.dropout)
         self.resid_dropout = nn.Dropout(config.dropout)
 
-        # Causal mask buffer (lower triangular, filled with -inf)
-        self.register_buffer(
-            "causal_mask",
-            torch.tril(torch.ones(config.context_length, config.context_length))
-            .view(1, 1, config.context_length, config.context_length),
-            persistent=False,
-        )
+        # RoPE
+        if self.use_rope:
+            self.rope = RotaryEmbedding(self.head_dim, config.context_length)
+
+        # Causal mask buffer (only needed for manual attention path)
+        if not self.use_flash_attention:
+            self.register_buffer(
+                "causal_mask",
+                torch.tril(torch.ones(config.context_length, config.context_length))
+                .view(1, 1, config.context_length, config.context_length),
+                persistent=False,
+            )
 
     def forward(self, x):
         """Forward pass through causal self-attention.
@@ -68,19 +124,27 @@ class CausalSelfAttention(nn.Module):
         k = k.view(B, T, self.n_heads, self.head_dim).transpose(1, 2)
         v = v.view(B, T, self.n_heads, self.head_dim).transpose(1, 2)
 
-        # Scaled dot-product attention: (B, n_heads, T, T)
-        scale = 1.0 / math.sqrt(self.head_dim)
-        att = (q @ k.transpose(-2, -1)) * scale
+        # Apply RoPE to Q and K (not V)
+        if self.use_rope:
+            cos, sin = self.rope(T)
+            q, k = apply_rotary_pos_emb(q, k, cos, sin)
 
-        # Apply causal mask (truncate to actual sequence length)
-        att = att.masked_fill(self.causal_mask[:, :, :T, :T] == 0, float("-inf"))
-
-        # Softmax + dropout
-        att = F.softmax(att, dim=-1)
-        att = self.attn_dropout(att)
-
-        # Weighted sum of values
-        y = att @ v  # (B, n_heads, T, head_dim)
+        if self.use_flash_attention:
+            # PyTorch 2.0+ scaled_dot_product_attention with automatic backend selection
+            y = F.scaled_dot_product_attention(
+                q, k, v,
+                attn_mask=None,
+                dropout_p=self.dropout_p if self.training else 0.0,
+                is_causal=True,
+            )
+        else:
+            # Manual attention path
+            scale = 1.0 / math.sqrt(self.head_dim)
+            att = (q @ k.transpose(-2, -1)) * scale
+            att = att.masked_fill(self.causal_mask[:, :, :T, :T] == 0, float("-inf"))
+            att = F.softmax(att, dim=-1)
+            att = self.attn_dropout(att)
+            y = att @ v
 
         # Reassemble heads and project
         y = y.transpose(1, 2).contiguous().view(B, T, C)
@@ -177,7 +241,8 @@ class GhostLM(nn.Module):
 
         # Embeddings
         self.token_embedding = nn.Embedding(config.vocab_size, config.d_model)
-        self.pos_embedding = nn.Embedding(config.context_length, config.d_model)
+        if not config.use_rope:
+            self.pos_embedding = nn.Embedding(config.context_length, config.d_model)
         self.dropout = nn.Dropout(config.dropout)
 
         # Transformer blocks
@@ -233,10 +298,13 @@ class GhostLM(nn.Module):
         )
 
         # Token + positional embeddings
-        pos = torch.arange(0, T, dtype=torch.long, device=idx.device)
         tok_emb = self.token_embedding(idx)
-        pos_emb = self.pos_embedding(pos)
-        x = self.dropout(tok_emb + pos_emb)
+        if self.config.use_rope:
+            x = self.dropout(tok_emb)
+        else:
+            pos = torch.arange(0, T, dtype=torch.long, device=idx.device)
+            pos_emb = self.pos_embedding(pos)
+            x = self.dropout(tok_emb + pos_emb)
 
         # Transformer blocks
         for block in self.blocks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 train = ["wandb>=0.16.0", "matplotlib>=3.8.0"]
+export = ["safetensors>=0.4.0"]
 data = ["datasets>=2.16.0", "tokenizers>=0.15.0", "requests>=2.31.0"]
 dev = ["pytest>=8.0.0"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ tokenizers>=0.15.0
 tiktoken>=0.5.0
 requests>=2.31.0
 tqdm>=4.66.0
+safetensors>=0.4.0
 wandb>=0.16.0
 pytest>=8.0.0
 matplotlib>=3.8.0

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -1,8 +1,9 @@
-"""GhostLM ONNX exporter — converts trained model to ONNX for deployment outside PyTorch."""
+"""GhostLM exporter — converts trained model to ONNX or safetensors for distribution."""
 
 import argparse
+import json
 import sys
-from dataclasses import fields
+from dataclasses import asdict, fields
 from pathlib import Path
 
 import torch
@@ -13,12 +14,12 @@ from ghostlm.tokenizer import GhostTokenizer
 
 
 def parse_args():
-    """Parse command-line arguments for ONNX export.
+    """Parse command-line arguments for model export.
 
     Returns:
         argparse.Namespace with all parsed export arguments.
     """
-    parser = argparse.ArgumentParser(description="Export GhostLM to ONNX format")
+    parser = argparse.ArgumentParser(description="Export GhostLM to ONNX or safetensors format")
 
     parser.add_argument(
         "--checkpoint",
@@ -27,16 +28,29 @@ def parse_args():
         help="Path to GhostLM checkpoint (.pt file)",
     )
     parser.add_argument(
+        "--format",
+        type=str,
+        choices=["onnx", "safetensors", "both"],
+        default="both",
+        help="Export format: onnx, safetensors, or both",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="exports",
+        help="Output directory for exported files",
+    )
+    parser.add_argument(
         "--output",
         type=str,
-        default="exports/ghostlm.onnx",
-        help="Output path for the ONNX model file",
+        default=None,
+        help="Output path for ONNX file (overrides --output-dir for ONNX)",
     )
     parser.add_argument(
         "--seq-len",
         type=int,
         default=64,
-        help="Sequence length for export",
+        help="Sequence length for ONNX export",
     )
     parser.add_argument(
         "--opset",
@@ -143,12 +157,52 @@ def verify_onnx(output_path: str) -> None:
         print(f"  ONNX verification failed: {e}")
 
 
-def main():
-    """Run the GhostLM ONNX export pipeline.
+def export_safetensors(model: GhostLM, config: GhostLMConfig, output_dir: str) -> None:
+    """Export the GhostLM model to safetensors format.
 
-    Loads a trained checkpoint, exports the model to ONNX format with
-    dynamic axes for flexible batch and sequence lengths, and optionally
-    verifies the exported model.
+    Saves model weights as a .safetensors file (no arbitrary code execution
+    risk) and config as a JSON sidecar for easy reconstruction.
+
+    Args:
+        model: GhostLM model in eval mode.
+        config: GhostLMConfig with model hyperparameters.
+        output_dir: Directory to write the safetensors and config files.
+    """
+    try:
+        from safetensors.torch import save_file
+    except ImportError:
+        print("  Error: safetensors not installed. Run: pip install safetensors")
+        return
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Save weights
+    weights_path = output_path / "ghostlm.safetensors"
+    save_file(model.state_dict(), str(weights_path))
+    file_size = weights_path.stat().st_size / (1024 * 1024)
+    print(f"  Saved weights: {weights_path} ({file_size:.1f} MB)")
+
+    # Save config as JSON sidecar
+    config_path = output_path / "config.json"
+    with open(config_path, "w") as f:
+        json.dump(asdict(config), f, indent=2)
+    print(f"  Saved config:  {config_path}")
+
+    # Generate SHA-256 checksum
+    import hashlib
+    sha256 = hashlib.sha256(weights_path.read_bytes()).hexdigest()
+    checksum_path = output_path / "ghostlm.safetensors.sha256"
+    checksum_path.write_text(f"{sha256}  ghostlm.safetensors\n")
+    print(f"  Saved checksum: {checksum_path}")
+    print(f"  SHA-256: {sha256}")
+
+
+def main():
+    """Run the GhostLM export pipeline.
+
+    Loads a trained checkpoint and exports the model to ONNX and/or
+    safetensors format for distribution.
     """
     args = parse_args()
 
@@ -161,30 +215,31 @@ def main():
     # Load model
     model, config = load_model(str(checkpoint_path), args.device)
 
-    # Create output directory
-    output_path = Path(args.output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Print header
     print("=" * 50)
-    print("GhostLM ONNX Export")
+    print("GhostLM Export")
     print("=" * 50)
     print(f"  Checkpoint: {checkpoint_path}")
-    print(f"  Output:     {output_path}")
-    print(f"  Seq length: {args.seq_len}")
-    print(f"  Opset:      {args.opset}")
+    print(f"  Format:     {args.format}")
+    print(f"  Output dir: {output_dir}")
     print(f"  Params:     {model.num_params():,}")
     print("=" * 50)
 
-    # Export
-    print("\nExporting to ONNX...")
-    export_onnx(model, config, str(output_path), args.seq_len, args.opset)
+    if args.format in ("safetensors", "both"):
+        print("\nExporting to safetensors...")
+        export_safetensors(model, config, str(output_dir))
 
-    # Verify
-    print("\nVerifying ONNX model...")
-    verify_onnx(str(output_path))
+    if args.format in ("onnx", "both"):
+        onnx_path = args.output or str(output_dir / "ghostlm.onnx")
+        print("\nExporting to ONNX...")
+        export_onnx(model, config, onnx_path, args.seq_len, args.opset)
+        print("\nVerifying ONNX model...")
+        verify_onnx(onnx_path)
 
-    print(f"\nExport complete: {output_path}")
+    print(f"\nExport complete: {output_dir}")
 
 
 if __name__ == "__main__":

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -128,3 +128,107 @@ def test_model_num_params():
 
     assert n_params > 0
     assert n_params < 50_000_000
+
+
+def test_model_with_rope():
+    """Test that model works with RoPE enabled."""
+    config = GhostLMConfig.from_preset("ghost-tiny")
+    config.vocab_size = 50261
+    config.context_length = 64
+    config.use_rope = True
+
+    model = GhostLM(config)
+    x = torch.randint(0, 50261, (2, 32))
+
+    logits, loss = model(x)
+    assert logits.shape == (2, 32, 50261)
+
+    # RoPE model should not have pos_embedding
+    assert not hasattr(model, "pos_embedding")
+
+
+def test_model_with_rope_and_loss():
+    """Test that RoPE model computes loss correctly."""
+    config = GhostLMConfig.from_preset("ghost-tiny")
+    config.vocab_size = 50261
+    config.context_length = 64
+    config.use_rope = True
+
+    model = GhostLM(config)
+    x = torch.randint(0, 50261, (2, 32))
+
+    logits, loss = model(x, targets=x)
+    assert loss is not None
+    assert loss.item() > 0
+
+
+def test_model_with_flash_attention():
+    """Test that model works with Flash Attention enabled."""
+    config = GhostLMConfig.from_preset("ghost-tiny")
+    config.vocab_size = 50261
+    config.context_length = 64
+    config.use_flash_attention = True
+
+    model = GhostLM(config)
+    x = torch.randint(0, 50261, (2, 32))
+
+    logits, loss = model(x, targets=x)
+    assert logits.shape == (2, 32, 50261)
+    assert loss is not None
+    assert loss.item() > 0
+
+
+def test_model_with_rope_and_flash_attention():
+    """Test that RoPE and Flash Attention work together."""
+    config = GhostLMConfig.from_preset("ghost-tiny")
+    config.vocab_size = 50261
+    config.context_length = 64
+    config.use_rope = True
+    config.use_flash_attention = True
+
+    model = GhostLM(config)
+    x = torch.randint(0, 50261, (2, 32))
+
+    logits, loss = model(x, targets=x)
+    assert logits.shape == (2, 32, 50261)
+    assert loss is not None
+
+
+def test_rope_and_learned_pos_output_differ():
+    """Test that RoPE and learned positional embeddings produce different outputs."""
+    torch.manual_seed(42)
+    config_rope = GhostLMConfig.from_preset("ghost-tiny")
+    config_rope.vocab_size = 50261
+    config_rope.context_length = 64
+    config_rope.use_rope = True
+
+    torch.manual_seed(42)
+    config_learned = GhostLMConfig.from_preset("ghost-tiny")
+    config_learned.vocab_size = 50261
+    config_learned.context_length = 64
+    config_learned.use_rope = False
+
+    model_rope = GhostLM(config_rope)
+    model_learned = GhostLM(config_learned)
+
+    x = torch.randint(0, 50261, (1, 16))
+
+    logits_rope, _ = model_rope(x)
+    logits_learned, _ = model_learned(x)
+
+    # Outputs should differ since position encoding method is different
+    assert not torch.allclose(logits_rope, logits_learned)
+
+
+def test_model_generate_with_rope():
+    """Test autoregressive generation works with RoPE."""
+    config = GhostLMConfig.from_preset("ghost-tiny")
+    config.vocab_size = 50261
+    config.context_length = 64
+    config.use_rope = True
+
+    model = GhostLM(config)
+    x = torch.randint(0, 50261, (1, 10))
+
+    generated = model.generate(x, max_new_tokens=20)
+    assert generated.shape == (1, 30)


### PR DESCRIPTION
## Summary

Three major features for Phase 2 readiness:

### RoPE (Rotary Position Embeddings)
- `use_rope=True` in config replaces learned positional embeddings
- Encodes relative position directly into Q/K attention vectors
- Used by LLaMA, Mistral, and most modern architectures
- Generalizes better to unseen sequence lengths

### Flash Attention
- `use_flash_attention=True` uses PyTorch 2.0+ `scaled_dot_product_attention`
- Automatic backend selection (FlashAttention, Memory-Efficient, or Math)
- Reduces attention memory from O(n²) to O(n)
- Falls back to manual attention when disabled

### Safetensors Export
- `python scripts/export.py --format safetensors` exports weights safely
- No arbitrary code execution risk (unlike pickle-based .pt files)
- Generates config.json sidecar + SHA-256 checksum
- Ready for HuggingFace Hub distribution

## Test Plan
- [x] 16/16 tests pass (6 new)
- [x] RoPE forward pass and generation
- [x] Flash Attention with loss computation
- [x] Combined RoPE + Flash Attention
- [x] Output divergence between RoPE and learned embeddings
- [x] All existing tests unchanged

Closes #2, closes #7