### PR TITLE
v0.9.34: wandb wiring, torch.compile, gradient checkpointing + DDP dress rehearsal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ logs/
 .ipynb_checkpoints/
 checkpoints/
 !checkpoints/.gitkeep
+
+# Weights & Biases local run data
+wandb/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1360,6 +1360,71 @@ ghost-base v1.0 GPU run. Currently empty.
 
 ---
 
+## [0.9.34] — 2026-06-10 — GPU-run prep: wandb wiring, torch.compile, gradient checkpointing, DDP dress rehearsal
+
+The three items flagged as blocking for the ghost-base GPU spend, plus
+an end-to-end dress rehearsal of the new training path on Mac.
+
+### Added
+
+- **Weights & Biases is actually wired now.** `config.use_wandb`
+  existed (with a `--no-wandb` CLI flag and a wandb dependency) but
+  the trainer never imported or called wandb — a paid multi-day run
+  would have had no live metrics. `GhostTrainer` now streams per-step
+  `train/loss`, `train/lr`, `train/step_time_s` and per-eval
+  `eval/val_loss` etc., rank-0 only, with `wandb.init` config capture
+  and `finish()` on completion. Degrades to a warning (training
+  continues) if wandb is missing or unreachable. New `--wandb` /
+  `--wandb-project` flags on `scripts/train.py` and
+  `scripts/train_ghost_base.py`; `wandb_project` config field.
+  Verified end-to-end with `WANDB_MODE=offline`.
+- **`--compile` (torch.compile)**: wraps the model after optimizer
+  creation and before the DDP wrap (nanoGPT order). Typically a
+  1.3-1.8x step-time win on CUDA. Checkpoint save/load unwraps the
+  `OptimizedModule` so state dicts stay prefix-free and loadable
+  anywhere (`GhostTrainer._unwrap_model` peels DDP + compile).
+- **`--grad-checkpoint` (gradient checkpointing)**: recomputes block
+  activations in backward (`use_reentrant=False`) for a large
+  activation-memory cut at ~25-30% step-time cost — what makes the
+  ghost-1b/3b shapes fit per card. Only active in training mode;
+  KV-cached inference is untouched. Loss and gradients verified
+  identical with/without.
+
+### Fixed
+
+- **DDP crashed at startup**: `train()` called `self.model.num_params()`,
+  which `DistributedDataParallel` does not forward — any torchrun
+  launch died before step 0 (found by the dress rehearsal, fixed via
+  `_unwrap_model()`).
+
+### Dress rehearsal (Mac, ghost-tiny)
+
+- rebuild_corpus -> pretokenize -> `.bin` smoke train: pretokenizer
+  ran at ~4.6M tokens/s (the full 422M-token corpus is a ~90s one-time
+  job); warmup LR observably starts at the floor; checkpoints + both
+  log formats written.
+- 2-process `torchrun` (gloo, CPU) with `--grad-checkpoint`: trains,
+  rank-0-only output, one checkpoint writer, and `DistributedSampler`
+  shards verified disjoint across ranks (0 overlap in 2,000 sampled
+  indices per rank).
+- KV-cache benchmark, ghost-small-v0.5 (45M) on CPU, 64-token prompt
+  + 200 new tokens: **41.3 -> 223.4 tok/s (5.4x)** vs the uncached
+  loop.
+- Note: the local `data/raw` currently rebuilds to only 38,588 train
+  records (~31M tokens) — the v0.9.32 768K-record corpus's big
+  sources (primus_fineweb, fineweb_edu, code_corpus) are not on this
+  disk and need re-pulling (or restoring) before the real run.
+
+### Tests
+
+- 5 new tests (`tests/test_gpu_run_prep.py`): wandb init/log/finish
+  via a stub module, graceful degradation when wandb is broken,
+  compile wrap + prefix-free checkpoints, gradient-checkpointing
+  loss/grad parity, and checkpointing × KV-cache non-interference.
+  440 tests green.
+
+---
+
 ## [0.9.33] — 2026-06-09 — full-codebase review: KV cache, memmap corpus, DDP sharding, LR/init fixes
 
 A top-to-bottom review of the training and inference stack ahead of

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/PyTorch-2.0%2B-orange.svg" alt="PyTorch">
-  <img src="https://img.shields.io/badge/version-0.9.33-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.9.34-blue.svg" alt="Version">
 </p>
 
 # GhostLM
@@ -16,7 +16,7 @@
 
 > **Sister project**: [`ghostloop`](https://github.com/joemunene-by/ghostloop) is the embodied-AI sibling — same `GhostAgent`-shaped tool-using runtime + fail-closed safety pipeline + GhostBench-shaped paired-comparison eval, applied to **robot motion primitives** instead of CVE / MITRE / CWE lookups. Shipped v0.3.0 on 2026-05-10 with PyBullet + MuJoCo backends, MuJoCo Menagerie loader, episode catalogue, trace replay, five policy gates (DenyList / RateLimit / Geofence / ForceCap / HITL), and a `python -m ghostloop` CLI. The thesis: as VLA models become the policy substrate, the runtime around them needs the same rigor we already apply to LLM tool use.
 
-> **Status (v0.9.33 — 2026-06-09):** training/inference stack hardened ahead of the ghost-base GPU run — KV-cached generation, memory-mapped pretokenized corpus, real DDP data sharding, LR-schedule and SwiGLU-init fixes. The v1.0 pretrain corpus stands at 768,741 train / 40,429 val records (~422M tokens), code share 11.6%, cybersec sources ~65% of text. The GhostAgent tool-using runtime, multi-vendor HTTP server (OpenAI / Anthropic / Gemini / Ollama wire formats), MCP integration, and the GhostBench statistical eval suite are all shipped. **ghost-base (~360M params) is the v1.0 training target, gated on rented GPU compute.** Dated, per-version detail lives in [CHANGELOG.md](CHANGELOG.md).
+> **Status (v0.9.34 — 2026-06-10):** training/inference stack hardened ahead of the ghost-base GPU run — KV-cached generation (5.4× faster decoding), memory-mapped pretokenized corpus, real DDP data sharding, LR-schedule and SwiGLU-init fixes, plus live wandb metrics, `--compile`, and `--grad-checkpoint` flags, all dress-rehearsed end-to-end on Mac. The v1.0 pretrain corpus stands at 768,741 train / 40,429 val records (~422M tokens), code share 11.6%, cybersec sources ~65% of text. The GhostAgent tool-using runtime, multi-vendor HTTP server (OpenAI / Anthropic / Gemini / Ollama wire formats), MCP integration, and the GhostBench statistical eval suite are all shipped. **ghost-base (~360M params) is the v1.0 training target, gated on rented GPU compute.** Dated, per-version detail lives in [CHANGELOG.md](CHANGELOG.md).
 
 GhostLM is a decoder-only transformer language model. Pretrained from scratch on CVE descriptions, CTF writeups, MITRE/CWE/OWASP/RFC reference material, NIST SP 800 publications, security research blogs, security tool source code, FineWeb-Edu educational web text, and open-web-math reasoning. No pretrained weights, no wrappers, every component written by hand.
 
@@ -115,6 +115,9 @@ make train-small
 
 # Multi-GPU (DDP): data is sharded per rank via DistributedSampler
 torchrun --nproc_per_node=4 scripts/train.py --preset ghost-small ...
+
+# GPU-run extras: live wandb metrics, torch.compile, gradient checkpointing
+python scripts/train_ghost_base.py --wandb --compile --grad-checkpoint ...
 ```
 
 ### Generate Text

--- a/ghostlm/config.py
+++ b/ghostlm/config.py
@@ -61,6 +61,14 @@ class GhostLMConfig:
     dtype: str = "float32"
     seed: int = 42
     use_wandb: bool = False
+    wandb_project: str = "ghostlm"
+    # torch.compile the model before training. Typically a 1.3-1.8x
+    # throughput win on CUDA; first step pays a compilation stall.
+    use_compile: bool = False
+    # Recompute block activations in backward instead of storing them.
+    # Trades ~25-30% step time for a large activation-memory cut —
+    # what makes ghost-1b/3b shapes fit on a single card.
+    gradient_checkpointing: bool = False
 
     def num_params(self) -> int:
         """Return the exact trainable parameter count for this config.
@@ -235,6 +243,8 @@ class GhostLMConfig:
             f"  dtype:           {self.dtype}",
             f"  seed:            {self.seed}",
             f"  use_wandb:       {self.use_wandb}",
+            f"  use_compile:     {self.use_compile}",
+            f"  grad_checkpoint: {self.gradient_checkpointing}",
             "=" * 40,
             f"Estimated size: {self.model_size()}",
         ]

--- a/ghostlm/model.py
+++ b/ghostlm/model.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.utils.checkpoint
 
 from ghostlm.config import GhostLMConfig
 
@@ -583,13 +584,28 @@ class GhostLM(nn.Module):
             pos_emb = self.pos_embedding(pos)
             x = self.dropout(tok_emb + pos_emb)
 
-        # Transformer blocks
+        # Transformer blocks. Gradient checkpointing recomputes each
+        # block's activations during backward instead of storing them —
+        # a large activation-memory cut for ~25-30% extra step time.
+        # Only sensible while training (and pointless with a KV cache).
+        use_ckpt = (
+            getattr(self.config, "gradient_checkpointing", False)
+            and self.training
+            and torch.is_grad_enabled()
+            and not use_cache
+        )
         presents: Optional[List[LayerKVCache]] = [] if use_cache else None
         for i, block in enumerate(self.blocks):
             layer_past = past_kv[i] if past_kv else None
-            x, present = block(
-                x, attn_mask=attn_mask, past_kv=layer_past, use_cache=use_cache,
-            )
+            if use_ckpt:
+                x, present = torch.utils.checkpoint.checkpoint(
+                    block, x, attn_mask, layer_past, use_cache,
+                    use_reentrant=False,
+                )
+            else:
+                x, present = block(
+                    x, attn_mask=attn_mask, past_kv=layer_past, use_cache=use_cache,
+                )
             if use_cache:
                 presents.append(present)
 

--- a/ghostlm/trainer.py
+++ b/ghostlm/trainer.py
@@ -100,6 +100,13 @@ class GhostTrainer:
         # Optimizer (built BEFORE wrapping in DDP so param groups see raw modules)
         self.optimizer = self.model.configure_optimizers(config)
 
+        # torch.compile — after optimizer creation (param groups bind the
+        # raw modules), before the DDP wrap (nanoGPT-style order). The
+        # first forward pays a compilation stall; steady-state steps are
+        # typically 1.3-1.8x faster on CUDA.
+        if getattr(config, "use_compile", False):
+            self.model = torch.compile(self.model)
+
         # DDP wrap. Each rank now sees a self.model that does the all-reduce
         # transparently in backward(). Other code paths that touch
         # self.model.* still work because DDP forwards attribute access.
@@ -128,6 +135,37 @@ class GhostTrainer:
         self.accum_steps = getattr(config, 'grad_accum_steps', 4)
         self.best_val_loss = float("inf")
         self.log: list = []
+
+        # Weights & Biases — live metrics for long (paid) runs. Rank-0
+        # only; degrades to a warning if wandb isn't installed or can't
+        # reach the network, so offline runs never crash on telemetry.
+        self.wandb_run = None
+        if getattr(config, "use_wandb", False) and self.is_main_process:
+            try:
+                import wandb
+                run_name = self.log_dir.name if self.log_dir.name != "logs" else None
+                self.wandb_run = wandb.init(
+                    project=getattr(config, "wandb_project", "ghostlm"),
+                    name=run_name,
+                    config=asdict(config),
+                    resume="allow",
+                )
+            except Exception as e:  # noqa: BLE001 - telemetry must not kill training
+                print(f"[warn] wandb logging disabled: {type(e).__name__}: {e}")
+                self.wandb_run = None
+
+    def _unwrap_model(self) -> GhostLM:
+        """Peel DDP and torch.compile wrappers off self.model.
+
+        Checkpoints must store plain GhostLM state dicts (no 'module.'
+        or '_orig_mod.' key prefixes) so they load anywhere.
+        """
+        model = self.model
+        if hasattr(model, "module"):  # DistributedDataParallel
+            model = model.module
+        if hasattr(model, "_orig_mod"):  # torch.compile OptimizedModule
+            model = model._orig_mod
+        return model
 
     def get_lr(self) -> float:
         """Compute the current learning rate using cosine decay with linear warmup.
@@ -258,8 +296,8 @@ class GhostTrainer:
         if getattr(self, "is_distributed", False) and not self.is_main_process:
             return
 
-        # Unwrap DDP to keep checkpoints loadable on a single GPU
-        raw_model = self.model.module if hasattr(self.model, "module") else self.model
+        # Unwrap DDP / torch.compile to keep checkpoints loadable anywhere
+        raw_model = self._unwrap_model()
 
         checkpoint = {
             "step": self.step,
@@ -292,8 +330,8 @@ class GhostTrainer:
         """
         checkpoint = torch.load(path, map_location=self.device, weights_only=False)
 
-        # Load into the raw model (works for DDP-wrapped or single-GPU)
-        raw_model = self.model.module if hasattr(self.model, "module") else self.model
+        # Load into the raw model (works under DDP / torch.compile wraps)
+        raw_model = self._unwrap_model()
         raw_model.load_state_dict(checkpoint["model_state_dict"])
         self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         if "grad_scaler_state_dict" in checkpoint:
@@ -321,6 +359,10 @@ class GhostTrainer:
             f.write(json.dumps(data) + "\n")
         with open(self.log_dir / "training_log.json", "w") as f:
             json.dump(self.log, f, indent=2)
+        if self.wandb_run is not None:
+            metrics = {f"eval/{k}": v for k, v in data.items()
+                       if isinstance(v, (int, float)) and k != "step"}
+            self.wandb_run.log(metrics, step=data.get("step", self.step))
 
     def train(self, train_loader, val_loader) -> None:
         """Run the main training loop.
@@ -341,7 +383,7 @@ class GhostTrainer:
                 if self.use_amp else "disabled"
             )
             print(f"Mixed precision (AMP): {amp_desc}")
-            print(f"Model size: {self.model.num_params():,} parameters")
+            print(f"Model size: {self._unwrap_model().num_params():,} parameters")
             print(f"Training from step {self.step} to {self.config.max_steps}")
 
         # Create iterator that cycles through train_loader. Under DDP the
@@ -373,6 +415,15 @@ class GhostTrainer:
 
                 pbar.set_postfix(loss=f"{loss:.4f}", lr=f"{lr:.2e}", dt=f"{dt:.3f}s")
                 pbar.update(1)
+
+                # Per-step stream so a stall or divergence is visible
+                # live, not at the next eval interval.
+                if self.wandb_run is not None:
+                    self.wandb_run.log(
+                        {"train/loss": loss, "train/lr": lr,
+                         "train/step_time_s": dt},
+                        step=self.step,
+                    )
 
                 # Periodic evaluation / checkpointing. When a step hits
                 # both intervals, evaluate once and reuse the result.
@@ -413,6 +464,9 @@ class GhostTrainer:
             "time": dt,
             "status": "complete",
         })
+
+        if self.wandb_run is not None:
+            self.wandb_run.finish()
 
         if self.is_main_process:
             print(f"Training log saved to {self.log_dir / 'training_log.json'}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghostlm"
-version = "0.9.33"
+version = "0.9.34"
 description = "Open-source language model built from scratch in PyTorch. Purpose-built for cybersecurity, with code, general language, and math reasoning folded into the v1.0 corpus."
 readme = "README.md"
 license = "MIT"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -81,9 +81,32 @@ def parse_args():
         help="Override context length (default: preset value, use 128 for low-RAM CPU training)",
     )
     parser.add_argument(
+        "--wandb",
+        action="store_true",
+        help="Enable Weights & Biases live metrics (rank-0 only).",
+    )
+    parser.add_argument(
+        "--wandb-project",
+        type=str,
+        default=None,
+        help="wandb project name (default: ghostlm).",
+    )
+    parser.add_argument(
         "--no-wandb",
         action="store_true",
         help="Disable wandb logging",
+    )
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        help="torch.compile the model (CUDA: typically 1.3-1.8x faster steps "
+        "after a first-step compilation stall).",
+    )
+    parser.add_argument(
+        "--grad-checkpoint",
+        action="store_true",
+        help="Gradient checkpointing: recompute block activations in backward. "
+        "Large activation-memory cut for ~25-30%% extra step time.",
     )
     parser.add_argument(
         "--run-name",
@@ -161,8 +184,16 @@ def main():
     config.grad_accum_steps = args.grad_accum
     if args.device != "auto":
         config.device = args.device
+    if args.wandb:
+        config.use_wandb = True
     if args.no_wandb:
         config.use_wandb = False
+    if args.wandb_project:
+        config.wandb_project = args.wandb_project
+    if args.compile:
+        config.use_compile = True
+    if args.grad_checkpoint:
+        config.gradient_checkpointing = True
 
     if args.context_length is not None:
         config.context_length = args.context_length

--- a/scripts/train_ghost_base.py
+++ b/scripts/train_ghost_base.py
@@ -81,6 +81,16 @@ def parse_args() -> argparse.Namespace:
                    help="Mixed-precision dtype (bf16 for H100, fp32 for MPS smoke)")
     p.add_argument("--resume", default=None,
                    help="Path to a checkpoint .pt to resume from")
+    p.add_argument("--wandb", action="store_true",
+                   help="Enable Weights & Biases live metrics (rank-0 only).")
+    p.add_argument("--wandb-project", default=None,
+                   help="wandb project name (default: ghostlm).")
+    p.add_argument("--compile", action="store_true",
+                   help="torch.compile the model (CUDA: ~1.3-1.8x faster "
+                        "steps after a first-step compilation stall).")
+    p.add_argument("--grad-checkpoint", action="store_true",
+                   help="Gradient checkpointing: large activation-memory "
+                        "cut for ~25-30%% extra step time.")
     return p.parse_args()
 
 
@@ -112,6 +122,11 @@ def main() -> None:
     config.log_dir = f"logs/{args.run_name}"
     config.device = args.device
     config.dtype = args.dtype
+    config.use_wandb = args.wandb
+    if args.wandb_project:
+        config.wandb_project = args.wandb_project
+    config.use_compile = args.compile
+    config.gradient_checkpointing = args.grad_checkpoint
     print(config)
 
     model = GhostLM(config)

--- a/tests/test_gpu_run_prep.py
+++ b/tests/test_gpu_run_prep.py
@@ -1,0 +1,144 @@
+"""Tests for the GPU-run-prep trainer features: wandb wiring,
+torch.compile checkpoint unwrapping, and gradient checkpointing."""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ghostlm.config import GhostLMConfig
+from ghostlm.model import GhostLM
+from ghostlm.trainer import GhostTrainer
+
+
+def _tiny_config(tmp_path, **overrides) -> GhostLMConfig:
+    cfg = GhostLMConfig(
+        n_layers=2, d_model=64, n_heads=4, d_ff=128,
+        vocab_size=200, context_length=32, dropout=0.0,
+        device="cpu", grad_accum_steps=1, warmup_steps=10,
+        checkpoint_dir=str(tmp_path / "ckpt"),
+        log_dir=str(tmp_path / "logs"),
+        **overrides,
+    )
+    return cfg
+
+
+def _batch():
+    torch.manual_seed(0)
+    return torch.randint(0, 200, (2, 8)), torch.randint(0, 200, (2, 8))
+
+
+class _WandbStub(types.ModuleType):
+    """Minimal wandb stand-in capturing init/log/finish calls."""
+
+    def __init__(self):
+        super().__init__("wandb")
+        self.init_kwargs = None
+        self.logged = []
+        self.finished = False
+
+    def init(self, **kwargs):
+        self.init_kwargs = kwargs
+        return self
+
+    def log(self, metrics, step=None):
+        self.logged.append((dict(metrics), step))
+
+    def finish(self):
+        self.finished = True
+
+
+def test_wandb_wiring(tmp_path, monkeypatch):
+    """use_wandb=True must init wandb, stream eval metrics, and finish."""
+    stub = _WandbStub()
+    monkeypatch.setitem(sys.modules, "wandb", stub)
+
+    cfg = _tiny_config(tmp_path, use_wandb=True, max_steps=2,
+                       eval_interval=1, save_interval=2)
+    trainer = GhostTrainer(GhostLM(cfg), cfg, use_amp=False)
+
+    assert trainer.wandb_run is stub
+    assert stub.init_kwargs["project"] == "ghostlm"
+    # the default "logs" dir gives no run name (wandb autogenerates one)
+    assert stub.init_kwargs["name"] is None
+
+    trainer._log({"step": 1, "train_loss": 2.0, "val_loss": 2.1, "lr": 1e-4})
+    eval_metrics = [m for m, _ in stub.logged if "eval/val_loss" in m]
+    assert eval_metrics and eval_metrics[0]["eval/val_loss"] == 2.1
+    # the literal "step" field must not be re-logged as a metric
+    assert "eval/step" not in eval_metrics[0]
+
+
+def test_wandb_missing_module_degrades_gracefully(tmp_path, monkeypatch):
+    """A broken/missing wandb must warn, not crash the trainer."""
+    monkeypatch.setitem(sys.modules, "wandb", None)  # import returns None -> AttributeError
+    cfg = _tiny_config(tmp_path, use_wandb=True)
+    trainer = GhostTrainer(GhostLM(cfg), cfg, use_amp=False)
+    assert trainer.wandb_run is None
+    # training still works
+    loss = trainer.train_step(_batch())
+    assert loss > 0
+
+
+def test_compile_wrap_and_clean_checkpoint(tmp_path):
+    """use_compile must wrap the model, and checkpoints must contain
+    plain GhostLM keys (no _orig_mod. prefix)."""
+    if not hasattr(torch, "compile"):
+        pytest.skip("torch.compile unavailable")
+    cfg = _tiny_config(tmp_path, use_compile=True)
+    trainer = GhostTrainer(GhostLM(cfg), cfg, use_amp=False)
+
+    assert hasattr(trainer.model, "_orig_mod")
+    assert isinstance(trainer._unwrap_model(), GhostLM)
+
+    trainer.save_checkpoint(val_loss=1.0)
+    ckpt = torch.load(tmp_path / "ckpt" / "checkpoint_step_0.pt",
+                      map_location="cpu", weights_only=False)
+    assert all(not k.startswith("_orig_mod.")
+               for k in ckpt["model_state_dict"])
+    assert "token_embedding.weight" in ckpt["model_state_dict"]
+
+
+def test_gradient_checkpointing_matches_plain_backward(tmp_path):
+    """Same weights + same batch: loss and gradients must be identical
+    with and without gradient checkpointing."""
+    x, y = _batch()
+
+    losses, grads = [], []
+    for ckpt_on in (False, True):
+        torch.manual_seed(7)
+        cfg = _tiny_config(tmp_path, gradient_checkpointing=ckpt_on,
+                           use_rope=True, use_swiglu=True, use_rmsnorm=True)
+        model = GhostLM(cfg)
+        model.train()
+        _, loss = model(x, targets=y)
+        loss.backward()
+        losses.append(loss.item())
+        grads.append(model.blocks[0].attn.c_qkv.weight.grad.clone())
+
+    assert losses[0] == pytest.approx(losses[1], rel=1e-6)
+    assert torch.allclose(grads[0], grads[1], atol=1e-6)
+
+
+def test_gradient_checkpointing_skipped_in_eval_and_cache():
+    """Checkpointing must not interfere with eval-mode KV-cached decoding."""
+    torch.manual_seed(0)
+    cfg = GhostLMConfig(
+        n_layers=2, d_model=64, n_heads=4, d_ff=128,
+        vocab_size=200, context_length=32, dropout=0.0,
+        gradient_checkpointing=True,
+    )
+    model = GhostLM(cfg)
+    model.eval()
+    x = torch.randint(0, 200, (1, 8))
+    full, _ = model(x)
+    logits, _, kv = model(x[:, :4], use_cache=True)
+    pieces = [logits]
+    for t in range(4, 8):
+        logits, _, kv = model(x[:, t:t + 1], past_kv=kv, use_cache=True)
+        pieces.append(logits)
+    assert torch.allclose(full, torch.cat(pieces, dim=1), atol=1e-4)


### PR DESCRIPTION
The three blocking items for the ghost-base GPU run, plus an end-to-end dress rehearsal of the new training path.

## Added

- **wandb is actually wired now** — `use_wandb` existed but the trainer never imported wandb; a paid multi-day run would have had no live metrics. Per-step `train/loss`/`train/lr`/`train/step_time_s` + per-eval metrics, rank-0 only, graceful degradation if wandb is missing/unreachable. `--wandb` / `--wandb-project` on both train scripts. Verified with `WANDB_MODE=offline`.
- **`--compile`** — torch.compile after optimizer creation, before DDP wrap; `_unwrap_model()` keeps checkpoints prefix-free (no `_orig_mod.`/`module.` keys).
- **`--grad-checkpoint`** — block-level activation recompute (`use_reentrant=False`); loss/grad parity with plain backward pinned by tests; inactive during eval/KV-cached decoding.

## Fixed

- **Every torchrun launch crashed before step 0**: `train()` called `self.model.num_params()`, which DDP doesn't forward. Found by the dress rehearsal.

## Dress rehearsal (Mac, ghost-tiny)

- `rebuild_corpus` → `pretokenize` (~4.6M tok/s; full 422M corpus ≈ 90s one-time) → `.bin` smoke train: warmup LR observably starts at the floor, checkpoints + logs written.
- 2-process `torchrun` (gloo/CPU) with `--grad-checkpoint`: passes; `DistributedSampler` shards verified disjoint (0 overlap in 2,000 sampled indices/rank).
- **KV-cache benchmark**: ghost-small-v0.5 (45M), CPU, 64-token prompt + 200 new tokens — **41.3 → 223.4 tok/s (5.4×)**.

## ⚠️ Corpus finding

Local `data/raw` rebuilds to only **38,588 train records (~31M tokens)** — the v0.9.32 768K-record / 422M-token corpus's big sources (primus_fineweb, fineweb_edu, code_corpus) are not on this disk. They need re-pulling (or restoring from wherever the v0.9.32 rebuild ran) before the real GPU run.

## Tests

**440 passed, 3 skipped** (5 new in `tests/test_gpu_run_prep.py`). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)