### PR TITLE
fix(train): stale --preset choices rejected modern presets

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,7 +22,8 @@ def parse_args():
     parser.add_argument(
         "--preset",
         type=str,
-        choices=["ghost-tiny", "ghost-small", "ghost-medium"],
+        choices=["ghost-tiny", "ghost-small", "ghost-medium",
+                 "ghost-small-v0.5", "ghost-1b", "ghost-3b"],
         default="ghost-small",
         help="Model preset configuration (default: ghost-small)",
     )


### PR DESCRIPTION
Surfaced while attempting an M4 validation run: `scripts/train.py --preset ghost-small-v0.5` errors because the argparse `choices` list predates the v0.5 and MoE presets, even though `GhostLMConfig.from_preset` supports all six. One-line fix adding the missing presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)